### PR TITLE
Rename fabric-secure-chaincode to fabric-private-chaincode

### DIFF
--- a/labs/fabric-private-chaincode.md
+++ b/labs/fabric-private-chaincode.md
@@ -1,8 +1,8 @@
 # Lab Name
-Hyperledger Fabric Secure Chaincode Execution
+Hyperledger Fabric Private Chaincode 
 
 # Short Description
-This lab enables Secure Chaincode Execution using Intel SGX for
+This lab enables the execution of chaincodes using Intel SGX for
 Hyperledger Fabric.
 
 The transparency and resilience gained from blockchain protocols ensure the
@@ -23,7 +23,7 @@ within an enclave.  Furthermore, Fabric extensions for chaincode enclave
 registration and transaction verification are provided.
 
 # Scope of Lab
-This lab proposes an architecture to enable Secure Chaincode Execution
+This lab proposes an architecture to enable Private Chaincode
 using Intel SGX for Hyperledger Fabric.  We provide an initial
 proof-of-concept implementation of the proposed architecture. The main goal of
 this lab is to discuss and refine the proposed architecture involving


### PR DESCRIPTION
This PR proposes to rename fabric-secure-chaincode lab to fabric-private-chaincode for the following reasons:
- The previous name is misleading 
- The new name aligns with other fabric security features, such as `private data`
- This renaming decision has been made during the last Lab community meeting (April 30). See [meeting notes](https://docs.google.com/document/d/11wyn2uKx-UnhIw0XCogDwTDxW_IRqWiJ83HnY-kgBQ4/edit))

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>