### PR TITLE
Add attestation lab for Avalon and other projects

### DIFF
--- a/labs/dancap.md
+++ b/labs/dancap.md
@@ -1,0 +1,27 @@
+# Lab Name
+dancap
+
+# Short Description
+A lab for exploring trusted execution attestation API and deployment options for Hyperledger Avalon.
+
+# Scope of Lab
+This lab faciltates exploration of attestation options for Hyperledger Avalon and projects with
+similar requirements in Hyperledger such as Fabric Private Chaincode and the PDO lab.
+The lab aspires to two main goals and several related goals. There are several API / SDK options
+available to TEE projects. We want to find the best fit for Avalon. Second these APIs have
+infrastructure dependencies that may vary across deployment scenaries. This lab aims to find the
+the most portable deployment patterns.
+
+The less formal goals for the lab include creating clear examples of the APIs and possibly some
+utilities to facilitate testing for the availability of features in a hosted environment and or
+utilities for ease of deployment into various environments.
+
+# Initial Committers
+- https://github.com/dcmiddle
+
+# Sponsor
+- https://github.com/EugeneYYY - Hyperledger Avalon Maintainer
+
+# Pre-existing repository
+- https://github.com/dcmiddle/dancap
+


### PR DESCRIPTION
Create a lab for experimenting with Attestation APIs and deployment
models relevant to Hyperledger Avalon, Fabric Private Chaincode, and the
Private Data Objects lab.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>
