### PR TITLE
Add hint about asking sponsors approval on the PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 - [ ] Copy the short description of the proposal as the description of the PR
 - [ ] Remove this checklist section
 - [ ] Submit your PR and the labs stewards will review your proposal
-
+- [ ] Ask your sponsor to confirm sponsorship by stating so in a comment to the PR


### PR DESCRIPTION
Signed-off-by: trbs <trbs@trbs.net>

Update pull_request_template.md including a task to ask the sponsor to contact the stewards to confirm sponsorship.

Having the sponsor comment on the PR should normally be enough I think.
This helps stewards confirm a labs faster since they do not have to case the sponsor themselves for confirmation of sponsorship.