### PR TITLE
fabric-chaincode-OCaml

### DIFF
--- a/labs/fabric-chaincode-OCaml.md
+++ b/labs/fabric-chaincode-OCaml.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: fabric-chaincode-OCaml
+parent: Labs
+---
+# Lab Name
+fabric-chaincode-OCaml
+
+# Short Description
+Hyperledger Fabric Packages for OCaml Chaincode
+
+# Scope of Lab
+This lab aims at developping an API to write Hyperledger Fabric chaincodes in [OCaml](https://ocaml.org/).
+Such an API would enable the writting of formally proven chaincodes.
+Indeed, OCaml is a ML-based language prone to safe programming, and many formal proof tools are instrumented to generate OCaml code (Coq, Why3...).
+
+# Initial Committers
+- https://github.com/p1way - Pierre-Yves Piriou
+- https://github.com/bobot - François Bobot
+- https://github.com/JuRolland - Julien Rolland


### PR DESCRIPTION
Signed-off-by: Pierre-Yves PIRIOU <pierre-yves.piriou@edf.fr>

Hyperledger Fabric Packages for OCaml Chaincode

We have no sponsor because David Boswell said us that the TSC removes this requirement for creating a new lab.