### PR TITLE
Solang Playground

### DIFF
--- a/labs/Solang-playground.md
+++ b/labs/Solang-playground.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Solang Playground
+parent: Labs
+---
+
+# Lab Name
+Solang Playground
+
+# Short Description
+Solang playground is a web IDE for [Hyperledger Solang](https://github.com/hyperledger/solang). It is an easy way for Solidity developers to write, compile, deploy and interact with a Solidity contract deployed on Solana or Polkadot, without prior installation of any of the required tools (including Solang).
+
+# Scope of Lab
+
+Solang playground is a supporting project for [Hyperledger Solang](https://github.com/hyperledger/solang). If a comparison is made to the Ethereum ecosystem, Hyperledger Solang would be compared to [Solc](https://github.com/ethereum/solidity), while Solang playground would be compared to [Remix IDE](https://remix.ethereum.org/).
+
+# Initial Committers
+- https://github.com/salaheldinsoliman
+
+# Sponsor
+
+- https://github.com/seanyoung


### PR DESCRIPTION
Solang playground is a web IDE for [Hyperledger Solang](https://github.com/hyperledger/solang). It is an easy way for Solidity developers to write, compile, deploy and interact with a Solidity contract deployed on Solana or Polkadot, without prior installation of any of the required tools (including Solang).