### PR TITLE
fabric-debugger

### DIFF
--- a/labs/fabric-debugger.md
+++ b/labs/fabric-debugger.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: VS Code Plugin for Fabric Chaincode Developers
+parent: Labs
+---
+# Lab Name
+VS Code Plugin for Fabric Chaincode Developers
+
+
+# Short Description
+A VS code extension and toolbox to debugging a chaincode. The extension once installed can be used by developers of chaincode to run and debug from their IDE, to understand how their chaincode behaves.
+
+# Scope of Lab
+The objective of this project is to enhance the development experience for Hyperledger Fabric chaincode developers by integrating debugging capabilities into the VS Code IDE. The current setup and deployment process for debugging Fabric chaincode is often repetitive and time-consuming. By introducing a built-in debugging interface within the IDE, we aim to automate these tasks, thus streamlining and expediting the development process.
+## Key Deliverables:
+### Debugging Interface Integration:
+ - Develop and integrate a debugging interface into VS Code specifically tailored for Hyperledger Fabric chaincode.
+ - Ensure that this debugging tool can automate common setup and deployment steps, reducing manual intervention.
+### Adaptability Protocol:
+ - Implement the debugging extension using an adaptable protocol that allows for future reuse across other IDEs, ensuring flexibility and broad applicability.
+### Network Compatibility:
+ - Design the debugger to be compatible with any Hyperledger Fabric network, regardless of how it was deployed or the tools used for its deployment. This ensures that the debugger can be used in various development environments and scenarios.
+## Out of Scope:
+ - Deployment and setup of the Fabric network itself are not included in this project. The focus is solely on enabling debugging capabilities within the IDE.
+ - However, the project provides a shortcut within the IDE to quickly set up a network based on fabric-samples for development and testing purposes.
+
+This project aims to significantly enhance the productivity of Fabric chaincode developers by providing a robust and adaptable debugging solution within their preferred development environment.
+
+# Initial Committers
+- [Arun S M](https://github.com/arsulegai)
+- [Kent Lau](https://github.com/kentydotcom)
+- [Claudia](https://github.com/technomad01)
+- [Chinmayi D S](https://github.com/urgetolearn)
+- [Varsha](https://github.com/varshapichandi30)
+
+# Sponsor
+- [Arun S M](https://github.com/arsulegai) - Vice Chair, TOC
+
+# Pre-existing repository
+- https://github.com/arsulegai/fabric-debugger


### PR DESCRIPTION
A VS code extension and toolbox to debugging a chaincode. The extension once installed can be used by developers of chaincode to run and debug from their IDE, to understand how their chaincode behaves.
