### PR TITLE
Proposal for zkbk lab

### DIFF
--- a/labs/lfdt/zkbk.md
+++ b/labs/lfdt/zkbk.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: zkbk
+parent: LFDT Labs
+grand_parent: Active Labs
+---
+
+# Lab Name
+
+[zkbk](https://github.com/lf-decentralized-trust-labs/zkbk)
+
+# Short Description
+
+zkbk is a library for building first-person credentials, based on zero-knowledge proof systems. The library allows developers to create: 1) signing service for issuers to issue personhood credentials, 2) users to make attestations about other users; 3) users to produce showing proofs to varifiers.
+
+# Scope of Lab
+This open-source cryptography library implements the technical foundations of the First Person Project's decentralized trust architecture in conformance with emerging standards from the Linux Foundation Decentralized Trust (LFDT), Trust Over IP (ToIP), the Decentralized Identity Foundation (DIF), and W3C. Its scope covers cryptographic primitives and protocols for decentralized identifiers (DIDs), self-certifying identifiers (SCIDs), verifiable credentials (VCs), pairwise private channels (DIDComm/DWN), and privacy-preserving zero-knowledge proofs, with explicit support for the Trust Spanning Protocol (TSP). By providing rigorously specified, modular, and interoperable components, the library is intended as a reference implementation and developer toolkit for constructing agent wallets, verifiable personhood credentials, and decentralized trust graphs. In doing so, it aims to advance the realization of a globally scalable, privacy-preserving trust layer for the Internet.
+
+
+# Initial Committers
+
+- https://github.com/rsinha
+- https://github.com/Arka19
+- https://github.com/guruvamsi-policharla
+- https://github.com/hartm
+- https://github.com/keewoolee
+- https://github.com/sanjamg
+
+# Sponsor
+
+https://github.com/hendrikebbers - Hendrik Ebbers
+
+# Pre-existing repositories
+
+- https://github.com/rsinha/first-person-credentials


### PR DESCRIPTION
zkbk is a library for building first-person credentials, based on zero-knowledge proof systems. The library allows developers to create: 1) signing service for issuers to issue personhood credentials, 2) users to make attestations about other users; 3) users to produce showing proofs to varifiers.

## Checklist for LF Decentralized Trust Lab Proposal PR

- [x] Read [README.md](https://github.com/lf-decentralized-trust-labs/lf-decentralized-trust-labs.github.io/blob/master/README.md) carefully
- [x] Make sure your changes are committed with the proper sign-off
- [x] Use the labs name as the PR title
- [x] Copy the short description of the proposal as the description of the PR
- [ ] Remove this checklist section
- [ ] Submit your PR and the labs stewards will review your proposal
- [ ] Ask your sponsor to confirm sponsorship by stating so in a comment to the PR
