### PR TITLE
Hypernate

### DIFF
--- a/labs/lfdt/hypernate.md
+++ b/labs/lfdt/hypernate.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Hypernate
+parent: LFDT Labs
+grand_parent: Active Labs
+---
+# Lab Name
+Hypernate
+
+# Short Description
+A robust data mapper framework for JVM-based Hyperledger Fabric chaincode.
+
+# Scope of Lab
+If Fabric allows you to keep your familiar programming language, then Hypernate will allow you to *keep your familiar programming style.*
+
+No more low-level boilerplate code for key-value storage operations and other housekeeping tasks!
+Take advantage of Hypernate’s _high abstraction level, aspect-oriented approaches_ and _extensibility_ to keep your critical business logic as clean as possible!
+
+**Summary of current features:**
+1. Object-oriented CRUD (create, read, update, delete) operations with explicit semantics
+2. Declarative and flexible configuration of your entity keys
+3. An extensible chain of middleware processors handling non-business stuff (caching, logging, tracing, etc.)
+
+**A few additional features under development:**
+- Partial and range queries based on non-key attributes
+- Range query support for composite keys
+- Overall friendlier query support
+- OpenTelemetry integration
+- Support for data schemas
+
+# Initial Committers
+- https://github.com/bzp99
+- https://github.com/aklenik
+
+# Sponsor
+- https://github.com/aklenik - [Caliper](https://github.com/hyperledger-caliper/caliper) maintainer
+
+# Pre-existing repository
+- https://github.com/ftsrg/hypernate
+- https://github.com/ftsrg/hypernate-samples


### PR DESCRIPTION
## Short Lab Description

A robust data mapper framework for JVM-based Hyperledger Fabric chaincode.

> [!NOTE]
> I added the lab proposal document to the `lfdt/` subdirectory under `labs/` assuming that new Labs projects are supposted to go there.  Please let me know if that’s not the right place. 