### PR TITLE
Add Onboarding Diagnostics Lab proposal

### DIFF
--- a/labs/onboarding-diagnostics-lab.md
+++ b/labs/onboarding-diagnostics-lab.md
@@ -1,0 +1,84 @@
+---
+layout: default
+title: onboarding_diagnostics_lab
+parent: LFDT Labs
+grand_parent: Active Labs
+---
+
+# Lab Name
+
+Onboarding Diagnostics Lab
+
+# Short Description
+
+A layered onboarding validation and failure analysis toolchain that improves developer onboarding reliability by detecting, classifying, and resolving common setup and configuration issues in decentralized systems.
+
+# Scope of Lab
+
+This lab focuses on building practical developer tooling to reduce onboarding friction and improve contributor success rates in decentralized environments.
+
+The lab introduces a layered execution model:
+
+1. **Preflight Layer (zero-dependency)**  
+A minimal bootstrap check that can run before project dependencies are installed, intended to validate core local prerequisites such as Node.js, npm, PATH availability, and basic environment readiness.
+
+2. **CLI Diagnostics Layer (`idoa doctor`)**  
+A Node.js-based CLI for deeper onboarding validation, including dependency checks, configuration checks, local environment verification, failure classification, and actionable remediation guidance.
+
+3. **Adapter Layer**  
+System-specific onboarding checks that build on the shared diagnostics core. The initial reference adapter will target Hyperledger Fabric onboarding.
+
+---
+
+The lab will develop a working toolchain that:
+
+- validates local development environments
+- detects common onboarding failures during setup
+- classifies errors into structured categories
+- provides actionable remediation steps
+- outputs machine-readable JSON for automation and analysis
+
+---
+
+Initial implementation will include:
+
+- a zero-dependency preflight script for baseline system readiness checks
+- a core failure classification schema
+- environment and configuration validation checks in the CLI
+- a reference adapter for Hyperledger Fabric onboarding
+
+---
+
+The lab is designed as a reusable onboarding reliability layer that can be extended across multiple decentralized systems.
+
+This work aligns with LF Decentralized Trust's focus on developer experience, operational resilience, and sustainability by reducing early-stage contributor drop-off caused by opaque or inconsistent onboarding failures.
+
+---
+
+The lab aims to define a reusable failure classification model for onboarding across decentralized systems.
+
+The structured JSON output enables integration with CI pipelines, automated diagnostics, and support tooling.
+
+---
+
+### AI-assisted workflows (optional)
+
+The structured output format is designed to be compatible with AI-assisted workflows, enabling:
+
+- transformation of diagnostic results into human-readable explanations
+- automated generation of remediation steps
+- integration with AI-based developer support tools
+
+This is not a dependency of the system, but an optional extension enabled by the deterministic output format.
+
+# Initial Committers
+
+- https://github.com/Mateja3m
+
+# Sponsor
+
+TBD (seeking alignment within LF Decentralized Trust community)
+
+# Pre-existing repository
+
+https://github.com/Mateja3m/idoa


### PR DESCRIPTION
Adds a new LF Decentralized Trust Labs proposal: Onboarding Diagnostics Lab.

This lab focuses on reducing onboarding friction in decentralized systems through a layered diagnostics approach:

- a zero-dependency preflight layer (environment readiness)
- a Node.js CLI diagnostics layer (`idoa doctor`)
- a reusable adapter model (initial target: Hyperledger Fabric)

The goal is to make onboarding failures deterministic, interpretable, and actionable, improving developer experience and contributor success rates.

Pre-existing repository:
https://github.com/Mateja3m/idoa
