### PR TITLE
Semantic-Frameworks/claimont

### DIFF
--- a/labs/Semantic-Frameworks/claimont.md
+++ b/labs/Semantic-Frameworks/claimont.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Claim Ontology
+parent: https://github.com/Semantic-Frameworks as part of LFDT Labs
+grand_parent: Active Labs
+---
+
+# Lab Name
+
+https://github.com/Semantic-Frameworks/claimont
+
+# Short Description
+
+The Claim Ontology provides a formal semantic framework for representing claims, the entities that make them, and the evidence that supports them. It models defeasible claims (which can be challenged or overturned) as well as the various forms of substantiation that support or refute them. It is one of the four ontologies currently in the Anthropogenic Impact Accounting Ontology Suite (AIAO Suite).
+
+# Scope of Lab
+
+## Mission
+
+We provide an open-source framework to represent the basic concepts of anthropogenic impact accounting in a machine readable format.
+
+## Our Work
+
+The AIAO Suite is a tool for aggregating and consolidating impact accounting data across different standards and vocabularies. The ontology suite intends to be generic enough for anthropogenic impact accounting in almost any discipline and context, including climate action impact accounting.
+
+## Why it matters
+
+Standardising the semantics of impact data is a prerequisite for trustworthy, decentralised infrastructure. Without a shared vocabulary, ledgers, analytics and audit tools cannot reason over data in a comparable way. With the AIAO Suite we enable:
+
+- the exchange of impact data
+- the verification of impact evidence across platforms
+- the semantically explicit linking of claims and evidence
+- the reuse of common classes and properties
+- the mapping of legacy schemas into a common model
+
+The ontology suite is the product of collaboration by members of the Standards Working Group of the LFDT Climate Action & Accounting SIG.
+
+# Initial Committers
+
+- https://github.com/christiaanpauw
+- https://github.com/AlexIvanHoward
+
+# Sponsor
+
+This lab does not currently have a sponsor, but we can find one, if required.
+
+# Pre-existing repository
+
+- https://github.com/aiaont/claimont


### PR DESCRIPTION
The Claim Ontology provides a formal semantic framework for representing claims, the entities that make them, and the evidence that supports them. It models defeasible claims (which can be challenged or overturned) as well as the various forms of substantiation that support or refute them. It is one of the four ontologies currently in the Anthropogenic Impact Accounting Ontology Suite (AIAO Suite).
